### PR TITLE
Events appear in ga4

### DIFF
--- a/GoogleAnalytics.Ga4.DotNet.Sdk/Extensions/TimeSpanExtensions.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/Extensions/TimeSpanExtensions.cs
@@ -1,0 +1,9 @@
+﻿namespace GoogleAnalytics.Ga4.DotNet.Sdk.Extensions
+{
+    public static class TimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+
+        public static double TotalMicroseconds(this TimeSpan self) => self.Ticks * (1d / TicksPerMicrosecond);
+    }
+}

--- a/GoogleAnalytics.Ga4.DotNet.Sdk/GoogleAnalyticsGa4MiddleWare/TestMiddleWare.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/GoogleAnalyticsGa4MiddleWare/TestMiddleWare.cs
@@ -20,7 +20,7 @@ public class TestMiddleWare
     //private readonly Lazy<int> _httpsPort;
     private readonly int _statusCode;
 
-    private readonly string _measurmentId;
+    private readonly string _measurementId;
     private readonly IConfiguration _config;
     private readonly ILogger _logger;
 
@@ -45,7 +45,7 @@ public class TestMiddleWare
 
         var middleWareOptions = options.Value;
 
-        _measurmentId = middleWareOptions.MeasurementId;
+        _measurementId = middleWareOptions.MeasurementId;
 
 
         _logger = loggerFactory.CreateLogger<TestMiddleWare>();

--- a/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Client/BasicHttpClient.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Client/BasicHttpClient.cs
@@ -20,7 +20,7 @@ public class BasicHttpClient: IBasicHttpClient
     
     public async Task<HttpResponseMessage> PostAsync(string path, IEventRequest data)
     {
-        var fullPath = $"{path}?measurement_id={_settings.MeasurementId}&api_secret=${_settings.AppSecret}";
+        var fullPath = $"{path}?measurement_id={_settings.MeasurementId}&api_secret={_settings.AppSecret}";
         var hold = JsonSerializer.Serialize(data);
         
         // Send Message to GateWay

--- a/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Client/BasicHttpClient.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Client/BasicHttpClient.cs
@@ -20,8 +20,8 @@ public class BasicHttpClient: IBasicHttpClient
     
     public async Task<HttpResponseMessage> PostAsync(string path, IEventRequest data)
     {
-        var fullPath = $"{path}?measurement_id={_settings.MeasurmentId}&api_secret=${_settings.AppSecret}";
-        var hold =JsonSerializer.Serialize(data);
+        var fullPath = $"{path}?measurement_id={_settings.MeasurementId}&api_secret=${_settings.AppSecret}";
+        var hold = JsonSerializer.Serialize(data);
         
         // Send Message to GateWay
         return await _client.PostAsJsonAsync(fullPath, data, JsonHelper.GetOptions());

--- a/GoogleAnalytics.Ga4.DotNet.Sdk/Service/GASettings.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/Service/GASettings.cs
@@ -2,7 +2,7 @@
 
 public class GoogleAnalyticsClientSettings
 {
-    public string MeasurmentId { get; set; }
+    public string MeasurementId { get; set; }
     public string AppSecret { get; set; }
     
 }

--- a/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Request/EventRequest.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Request/EventRequest.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GoogleAnalytics.Ga4.DotNet.Sdk.Extensions;
 using GoogleAnalytics.Ga4.DotNet.Sdk.Service.Client;
 using GoogleAnalytics.Ga4.DotNet.Sdk.Service.Response;
 
@@ -19,7 +21,7 @@ public class EventRequest : IEventRequest
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("timestamp_micros")] 
-    public int TimestampMicros { get; set; }
+    public double TimestampMicros { get; set; }
 
     [JsonPropertyName("non_personalized_ads")]
     public bool NonPersonalizedAds { get; set; }
@@ -32,17 +34,15 @@ public class EventRequest : IEventRequest
     {
         if (string.IsNullOrWhiteSpace(clientId)) throw new ArgumentNullException(nameof(clientId));
         
-        var t = DateTime.UtcNow - new DateTime(1970, 1, 1);
-        var secondsSinceEpoch = (int)t.TotalSeconds;
-        
-        TimestampMicros = secondsSinceEpoch;
+        var timespanSinceEpoch = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        TimestampMicros = Math.Truncate(timespanSinceEpoch.TotalMicroseconds());
         ClientId = clientId;
     }
-    public EventRequest(string clientId, string userId) :this(clientId)
+    public EventRequest(string clientId, string userId) : this(clientId)
     {
         UserId = userId;
     }
-    public EventRequest(string clientId, string userId, bool nonPersonalizedAds = false) :this(clientId, userId)
+    public EventRequest(string clientId, string userId, bool nonPersonalizedAds = false) : this(clientId, userId)
     {
         NonPersonalizedAds = nonPersonalizedAds;
     }

--- a/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Request/EventRequest.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Request/EventRequest.cs
@@ -46,22 +46,20 @@ public class EventRequest : IEventRequest
     {
         NonPersonalizedAds = nonPersonalizedAds;
     }
-    public async Task<EventResponse> Send(bool debug =false)
+    public async Task<EventResponse> Send(bool debug = false)
     {
         var path = "/mp/collect";
         
-        if(debug) path = "/debug/mp/collect";
+        if (debug) path = "/debug/mp/collect";
         
         var response = await Client.PostAsync(path, this);
         var responseData = await response.Content.ReadAsStringAsync();
 
-        var data = JsonSerializer.Deserialize<DebugResponse>(responseData);
-
-        return new EventResponse()
+        return new EventResponse
         {
             IsSuccess = response.IsSuccessStatusCode,
             Message = response,
-            DebugResponse = (debug)? JsonSerializer.Deserialize<DebugResponse>(responseData) : null
+            DebugResponse = debug ? JsonSerializer.Deserialize<DebugResponse>(responseData) : null
         };
     }
 

--- a/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Request/IEventRequest.cs
+++ b/GoogleAnalytics.Ga4.DotNet.Sdk/Service/Request/IEventRequest.cs
@@ -15,7 +15,7 @@ public interface  IEventRequest
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("timestamp_micros")] 
-    public int TimestampMicros { get; set; }
+    public double TimestampMicros { get; set; }
 
     [JsonPropertyName("non_personalized_ads")]
     public bool NonPersonalizedAds { get; set; }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is an sdk designed for use with the [Google analytics ga4 measurement proto
 # settings
 
     "Ga4Settings": {
-       "MeasurmentId": "G-XXXXX",
+       "MeasurementId": "G-XXXXX",
        "AppSecret": "XXXX"
     }
 

--- a/Tests/Ga4Tests/EventRequestCreationTests.cs
+++ b/Tests/Ga4Tests/EventRequestCreationTests.cs
@@ -67,9 +67,6 @@ public class EventRequestCreationTests
         request.ClientId.ShouldBe(clientId);
         request.UserId.ShouldNotBeNullOrWhiteSpace();
         request.UserId.ShouldBe(userId);
-        
-      
-        
         request.TimestampMicros.ShouldNotBe(0);   // better way to check for min value.
     }
 }

--- a/Tests/Ga4Tests/SendDebugTests.cs
+++ b/Tests/Ga4Tests/SendDebugTests.cs
@@ -20,7 +20,7 @@ public class SendDebugTests
         return Options.Create(new GoogleAnalyticsClientSettings()
         {
             AppSecret = "XXXXX",
-            MeasurmentId = "G-XXXXXX",
+            MeasurementId = "G-XXXXXX",
         });
     }
     

--- a/WebApiClient/Controllers/WeatherForecastController.cs
+++ b/WebApiClient/Controllers/WeatherForecastController.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using GoogleAnalytics.Ga4.DotNet.Sdk.Extensions;
 using GoogleAnalytics.Ga4.DotNet.Sdk.Service;
 using GoogleAnalytics.Ga4.DotNet.Sdk.Service.Request;
@@ -28,8 +27,6 @@ public class WeatherForecastController : ControllerBase
     [HttpGet(Name = "GetWeatherForecast")]
     public async Task<IEnumerable<WeatherForecast>> Get()
     {
-    
-        
         var gaEvent = EventBuilders.BuildCustomEvent("test_event", new Dictionary<string, object>()).AddParameters("test","test");
         var request = new EventRequest("ClientId");
         request.AddEvent(gaEvent);

--- a/WebApiClient/appsettings.json
+++ b/WebApiClient/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "Ga4Settings": {
-    "MeasurmentId": "G-XXXXXXXX",
+    "MeasurementId": "G-XXXXXXXX",
     "AppSecret": "XXXXXX"
   }
 }


### PR DESCRIPTION
Hello, the text below is mostly copied from our previous conversation...

At this step my goal was to see at least one event that originates from the SDK code on my "Learn GA4" Analytics property. I set up one Android and one Web stream there but today used only the Web one as I saw your appsettings.json expects exactly this one.

I removed the debug param in WeatherForecastController to use "/mp/collect" instead of "/debug/mp/collect" and hoped some event appears on my GA4. That however was not the case. I had to set up few tools to be able to observer bit more closer what is happening. Namely Charles proxy and its SSL certificate and Postman where I tried to mimic the requests.

Thank to those tools I discovered 2 problems:

timestamp_micros value was set in seconds but must be in microseconds.

1. There was a tiny typo in URL formatting that added the $ character which made the request invalid.
2. The PR fixes the above plus some other smaller typos and formatting.

I am attaching few screenshots, mainly the one from GA. The "test_event" originates from SDK.
![image](https://user-images.githubusercontent.com/1670470/161536572-62a63ada-cc60-4d5a-b612-998192d249d1.png)

The other images are from Charles proxy capturing the traffic between SDK and Analytics server.
![image](https://user-images.githubusercontent.com/1670470/161536611-f311b147-933e-4613-b508-6e7ebb326dc0.png)

![image](https://user-images.githubusercontent.com/1670470/161536641-77419291-8d08-4705-82cf-774ab454dd3b.png)

I also touched unit tests that did not compile at the moment. I got them to green but did not make it part of this PR as I presume your plan is to extent mocks usage whereas my quick fix was 'gaOptions', i.e. these became rather integration tests communicating with "/debug/mp/collect".

My big goal would be to see the Users being captured in the Audience. This is still empty but we know that this is not in the scope of those first commits.
![image](https://user-images.githubusercontent.com/1670470/161536721-acec4d0d-e402-4e35-b93b-e7b40c6aa37d.png)

